### PR TITLE
Add optional argument to execute file close as a context manager

### DIFF
--- a/pyramid_storage/local.py
+++ b/pyramid_storage/local.py
@@ -74,6 +74,10 @@ class LocalFileStorage(object):
         """
         return open(self.path(filename), *args)
 
+    def close(self, filename):
+        # A method used only by the S3 implementation, but adding to keep the compatibility.
+        pass
+
     def delete(self, filename):
         """Deletes the filename. Filename is resolved with the
         absolute path based on base_path. If file does not exist,

--- a/pyramid_storage/local.py
+++ b/pyramid_storage/local.py
@@ -69,14 +69,10 @@ class LocalFileStorage(object):
         """
         return os.path.join(self.base_path, filename)
 
-    def open(self, filename, *args):
+    def open(self, filename, *args, **kwargs):
         """Return filelike object stored
         """
         return open(self.path(filename), *args)
-
-    def close(self, filename):
-        # A method used only by the S3 implementation, but adding to keep the compatibility.
-        pass
 
     def delete(self, filename):
         """Deletes the filename. Filename is resolved with the

--- a/pyramid_storage/s3.py
+++ b/pyramid_storage/s3.py
@@ -116,15 +116,12 @@ class S3FileStorage(object):
         bucket = self.get_bucket()
         key = bucket.get_key(filename) or bucket.new_key(filename)
 
-        as_context_manager = kwargs.get('as_ctx_mng', False)
-        f = tempfile.NamedTemporaryFile(delete=as_context_manager)
+        delete = kwargs.get('delete', False)
+        f = tempfile.NamedTemporaryFile(delete=delete)
         key.get_contents_to_filename(f.name)
 
-        if as_context_manager:
-            try:
-                return open(f.name, *args)
-            finally:
-                f.close()
+        if delete is True:
+            return f
 
         f.close()
 

--- a/pyramid_storage/s3v2.py
+++ b/pyramid_storage/s3v2.py
@@ -112,7 +112,7 @@ class S3V2FileStorage(S3FileStorage):
 
         if as_context_manager:
             try:
-                return open(f)
+                return open(f, *args)
             finally:
                 f.close()
 

--- a/pyramid_storage/s3v2.py
+++ b/pyramid_storage/s3v2.py
@@ -111,6 +111,15 @@ class S3V2FileStorage(S3FileStorage):
 
         return open(f.name, *args)
 
+    def close(self, filename):
+        """Removes a temporary file created [but not deleted] by the method `self.open`.
+        """
+
+        if filename not in self._opened_files:
+            raise ValueError('The file {} was not open by this instance.'.format(filename))
+        os.unlink(filename)
+        self._opened_files -= set([filename])
+
     def exists(self, filename):
         """
         Test if a file exists
@@ -118,7 +127,7 @@ class S3V2FileStorage(S3FileStorage):
         :return:
         """
         file_object = self.get_bucket().Object(filename)
-        try :
+        try:
             file_object.get()
             return True
         except file_object.meta.client.exceptions.NoSuchKey:
@@ -239,4 +248,3 @@ class S3V2FileStorage(S3FileStorage):
         """
         self.copy_file(src, dst)
         self.delete(src)
-

--- a/pyramid_storage/s3v2.py
+++ b/pyramid_storage/s3v2.py
@@ -105,16 +105,12 @@ class S3V2FileStorage(S3FileStorage):
         bucket = self.get_bucket()
         stream = bucket.Object(filename).get()['Body']
 
-        as_context_manager = kwargs.get('as_ctx_mng', False)
-
-        f = tempfile.NamedTemporaryFile(delete=as_context_manager)
+        delete = kwargs.get('delete', False)
+        f = tempfile.NamedTemporaryFile(delete=delete)
         f.write(stream.read())
 
-        if as_context_manager:
-            try:
-                return open(f, *args)
-            finally:
-                f.close()
+        if delete:
+            return f
 
         f.close()
 
@@ -127,7 +123,7 @@ class S3V2FileStorage(S3FileStorage):
         :return:
         """
         file_object = self.get_bucket().Object(filename)
-        try:
+        try :
             file_object.get()
             return True
         except file_object.meta.client.exceptions.NoSuchKey:
@@ -248,3 +244,4 @@ class S3V2FileStorage(S3FileStorage):
         """
         self.copy_file(src, dst)
         self.delete(src)
+

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -384,15 +384,10 @@ def test_open_simple_case():
         extensions="images")
 
     with mock.patch('pyramid_storage.s3.S3FileStorage.get_connection', _get_mock_s3_connection):
-        tmp_file = s.open('foo')
+        _file = s.open('foo')
 
-    assert os.path.isfile(tmp_file.name) is True
-
-    with tmp_file:
-        # just to ensure the fill will not be deleted
-        pass
-
-    assert os.path.isfile(tmp_file.name) is True
+    assert os.path.isfile(_file.name) is True
+    assert _file.closed is False
 
 
 def test_open_as_context_manager():
@@ -406,6 +401,9 @@ def test_open_as_context_manager():
         extensions="images")
 
     with mock.patch('pyramid_storage.s3.S3FileStorage.get_connection', _get_mock_s3_connection):
-        with s.open('foo', as_ctx_mng=True) as f:
-            tmp_file_name = f.name
-    assert os.path.isfile(tmp_file_name) is False
+        with s.open('foo', delete=True) as tmp_file:
+            assert tmp_file.closed is False
+            assert os.path.isfile(tmp_file.name) is True
+
+    assert tmp_file.closed is True
+    assert os.path.isfile(tmp_file.name) is False

--- a/tests/test_s3v2.py
+++ b/tests/test_s3v2.py
@@ -204,6 +204,8 @@ def test_open_as_context_manager():
 
     with mock.patch('pyramid_storage.s3.S3FileStorage.get_connection',
                     _get_mock_s3_connection):
-        with s.open('foo', as_ctx_mng=True) as f:
+        with s.open('foo', delete=True) as f:
             tmp_file_name = f.name
+            assert os.path.isfile(tmp_file_name) is True
+
     assert os.path.isfile(tmp_file_name) is False

--- a/tests/test_s3v2.py
+++ b/tests/test_s3v2.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import re
+import os
 
 import mock
 import pytest
 
 from pyramid import compat
-from pyramid import exceptions as pyramid_exceptions
 
 
 class MockBucket(mock.Mock):
@@ -18,10 +17,21 @@ class MockBucket(mock.Mock):
 
         return [mock_key_1]
 
+
 class MockS3Resource(object):
 
     def Bucket(self, bucket_name):
         return MockBucket()
+
+
+class MockS3Connection(object):
+
+    def get_bucket(self, bucket_name):
+        return MockBucket()
+
+
+def _get_mock_s3_connection(self):
+    return MockS3Connection()
 
 
 def _get_mock_s3_resource(self):
@@ -157,3 +167,43 @@ def test_save_if_randomize():
             _get_mock_s3_resource):
         name = s.save(fs, randomize=True)
     assert name != "test.jpg"
+
+
+def test_open_simple_case():
+
+    from pyramid_storage import s3v2
+
+    s = s3v2.S3FileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images")
+
+    with mock.patch('pyramid_storage.s3.S3FileStorage.get_connection',
+                    _get_mock_s3_connection):
+        tmp_file = s.open('foo')
+
+    assert os.path.isfile(tmp_file.name) is True
+
+    with tmp_file:
+        # just to ensure the fill will not be deleted
+        pass
+
+    assert os.path.isfile(tmp_file.name) is True
+
+
+def test_open_as_context_manager():
+
+    from pyramid_storage import s3v2
+
+    s = s3v2.S3FileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images")
+
+    with mock.patch('pyramid_storage.s3.S3FileStorage.get_connection',
+                    _get_mock_s3_connection):
+        with s.open('foo', as_ctx_mng=True) as f:
+            tmp_file_name = f.name
+    assert os.path.isfile(tmp_file_name) is False


### PR DESCRIPTION
A method to close (what means remove in this context) [this temporary but not deleted temporary file](https://github.com/geru-br/pyramid_storage/blob/master/pyramid_storage/s3.py#L118)

The idea is the use close this file explicitly until the method open be refactored.